### PR TITLE
Release: Deep Ocean dark theme and animated stat counters

### DIFF
--- a/frontend/src/components/sections/StatsSection.tsx
+++ b/frontend/src/components/sections/StatsSection.tsx
@@ -1,5 +1,59 @@
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Calendar, Users, MapPin, Headphones } from "lucide-react";
+
+/** Counts up from 0 to the number in `value` when scrolled into view.
+ *  Non-numeric parts stay as a suffix: "500+" -> 500 & "+", "24/7" -> 24 & "/7". */
+function AnimatedStat({ value }: { value: string }) {
+  const match = value.match(/^(\d+)(.*)$/);
+  const target = match ? parseInt(match[1], 10) : null;
+  const suffix = match ? match[2] : "";
+
+  const ref = useRef<HTMLDivElement>(null);
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (target === null) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    if (reducedMotion || typeof IntersectionObserver === "undefined") {
+      setCount(target);
+      return;
+    }
+
+    let frame = 0;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        observer.disconnect();
+
+        const duration = 1800;
+        const start = performance.now();
+        const tick = (now: number) => {
+          const progress = Math.min((now - start) / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3);
+          setCount(Math.round(eased * target));
+          if (progress < 1) frame = requestAnimationFrame(tick);
+        };
+        frame = requestAnimationFrame(tick);
+      },
+      { threshold: 0.4 }
+    );
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(frame);
+    };
+  }, [target]);
+
+  return (
+    <div ref={ref} className="text-3xl md:text-4xl font-bold tracking-tight text-white tabular-nums">
+      {target === null ? value : `${count}${suffix}`}
+    </div>
+  );
+}
 
 export function StatsSection() {
   const { t } = useTranslation();
@@ -20,7 +74,7 @@ export function StatsSection() {
               <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-white/15 mb-3 group-hover:bg-white/25 transition-colors">
                 <stat.icon className="h-6 w-6 text-white/90" />
               </div>
-              <div className="text-3xl md:text-4xl font-bold tracking-tight text-white">{stat.value}</div>
+              <AnimatedStat value={stat.value} />
               <div className="text-sm mt-1 text-white/70">{stat.label}</div>
             </div>
           ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,48 +59,50 @@
   }
 
   .dark {
-    --background: 220 25% 8%;         /* deep navy */
-    --foreground: 40 15% 92%;          /* warm off-white */
+    /* "Deep Ocean" dark theme: teal-tinted charcoal for brand character,
+       with a clear elevation ramp (bg 6.5% -> card 10.5% -> border 20%) */
+    --background: 192 25% 6.5%;       /* deep ocean charcoal */
+    --foreground: 40 20% 93%;          /* warm off-white */
 
-    --card: 220 22% 11%;              /* slightly lighter navy */
-    --card-foreground: 40 15% 92%;
+    --card: 192 20% 10.5%;            /* clearly elevated above bg */
+    --card-foreground: 40 20% 93%;
 
-    --popover: 220 22% 11%;
-    --popover-foreground: 40 15% 92%;
+    --popover: 192 20% 10.5%;
+    --popover-foreground: 40 20% 93%;
 
-    --primary: 172 40% 42%;           /* lighter teal — keeps brand */
-    --primary-foreground: 220 25% 8%;
+    --primary: 172 48% 48%;           /* brighter teal, pops on dark */
+    --primary-foreground: 195 30% 6%;
 
-    --secondary: 220 18% 14%;         /* dark warm gray */
+    --secondary: 192 15% 15%;
     --secondary-foreground: 40 15% 90%;
 
-    --muted: 220 18% 14%;
-    --muted-foreground: 220 12% 55%;
+    --muted: 192 15% 14%;
+    --muted-foreground: 200 10% 67%;  /* readable secondary text */
 
-    --accent: 40 92% 56%;             /* warm gold — stays warm */
-    --accent-foreground: 220 25% 8%;
+    --accent: 41 95% 58%;             /* warm gold, slightly brighter */
+    --accent-foreground: 30 30% 8%;
 
     --destructive: 0 62% 40%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 220 18% 16%;
-    --input: 220 18% 16%;
-    --ring: 172 40% 42%;
+    --border: 190 15% 20%;            /* visible card edges */
+    --input: 190 15% 20%;
+    --ring: 172 48% 48%;
 
-    --sidebar-background: 220 25% 8%;
+    --sidebar-background: 192 25% 6.5%;
     --sidebar-foreground: 40 15% 90%;
-    --sidebar-primary: 172 40% 42%;
-    --sidebar-primary-foreground: 220 25% 8%;
-    --sidebar-accent: 220 18% 14%;
+    --sidebar-primary: 172 48% 48%;
+    --sidebar-primary-foreground: 195 30% 6%;
+    --sidebar-accent: 192 15% 14%;
     --sidebar-accent-foreground: 40 15% 90%;
-    --sidebar-border: 220 18% 16%;
-    --sidebar-ring: 172 40% 42%;
+    --sidebar-border: 190 15% 20%;
+    --sidebar-ring: 172 48% 48%;
 
-    --gradient-hero: linear-gradient(135deg, hsl(172 40% 30%), hsl(172 35% 40%));
+    --gradient-hero: linear-gradient(135deg, hsl(174 55% 20%), hsl(188 48% 28%));
     --gradient-gold: linear-gradient(135deg, hsl(42 92% 56%), hsl(36 88% 50%));
-    --shadow-elegant: 0 4px 20px -4px hsl(0 0% 0% / 0.3);
+    --shadow-elegant: 0 4px 20px -4px hsl(0 0% 0% / 0.45);
     --shadow-glow: 0 0 30px hsl(38 70% 55% / 0.15);
-    --shadow-lifted: 0 12px 40px -12px hsl(0 0% 0% / 0.4);
+    --shadow-lifted: 0 12px 40px -12px hsl(0 0% 0% / 0.55);
   }
 }
 


### PR DESCRIPTION
Promotes dev to main. Contains #9:

- Dark mode reworked as "Deep Ocean": teal-tinted charcoal with proper elevation contrast, visible card borders, readable secondary text, brighter teal accents
- Stats numbers count up to their targets (6+, 500+, 50+, 24/7) when scrolled into view, with reduced-motion fallback

Browser-verified in dark and light mode; typecheck, lint, and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)